### PR TITLE
v1.3.5 - Scorescreen Race Condition Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "materia": {
     "cleanName": "crossword"
   },
-  "version": "1.3.4",
+  "version": "1.3.5",
   "dependencies": {
     "hammerjs": "2.0.6",
     "materia-widget-development-kit": "3.0.4"

--- a/src/scoreScreen.coffee
+++ b/src/scoreScreen.coffee
@@ -87,12 +87,10 @@ Namespace('Crossword').ScoreScreen = do ->
 
 	# Called by Materia.ScoreCore when user switches score attempt
 	update = (qset, scoreTable) ->
-		_scoreTable = scoreTable
+		if not _qset or not isConsistentQset(qset)
+			return redrawBoard(qset, scoreTable)
 
-		if not isConsistentQset(qset)
-			return redrawBoard(qset)
-
-		_qset = qset
+		_qset = qset;
 		answersShown = $('#hide-correct')[0].checked
 		$('.letter').removeClass('correct incorrect')
 		forEveryQuestion (i, letters, x, y, dir, response) ->
@@ -273,9 +271,11 @@ Namespace('Crossword').ScoreScreen = do ->
 				_puzzleGrid[letterTop][letterLeft] = letters[l]
 				_boardDiv.append letterElement
 
-	redrawBoard = (qset) ->
+	redrawBoard = (qset, scoreTable) ->
 		_qset = qset
 		_questions = _qset.items[0].items
+		_scoreTable = scoreTable
+		_boardDiv = $('#movable')
 		forEveryQuestion (i, letters, x, y, dir, response) ->
 			_questions[i].options.x = ~~_questions[i].options.x
 			_questions[i].options.y = ~~_questions[i].options.y


### PR DESCRIPTION
This PR backports the fix for the race condition on scorescreen laod from the v1.4.0 PR.

The race condition is likely from Materia scorecore, and results in the scorescreen update being called before scoresceen start. In this widget, there were variables only defined in the start function that were null in update, causing the scorescreen render to fail. Now these variables are redefined in the redrawBoard function.