### PR TITLE
Fix for out of range scoring errors

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.13.0]
+        node-version: [25]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.13.0]
+        node-version: [25]
 
     steps:
     - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "version": "1.4.0",
   "dependencies": {
-    "materia-widget-development-kit": "^3.0.4"
+    "materia-widget-development-kit": "3.0.5"
   },
   "scripts": {
     "start": "mwdk-start",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 79
+
+[tool.isort]
+profile = "black"

--- a/src/_score/score_module.py
+++ b/src/_score/score_module.py
@@ -23,15 +23,10 @@ class Crossword(ScoreModule):
         answer = self.normalize_string(correct_text)
         response = self.normalize_string(log.text)
 
-        max_len = max(len(answer), len(response))
-
         match_num = 0
         guessable = 0
 
-        for i in range(max_len):
-
-            if i >= len(answer):
-                break
+        for i in range(len(answer)):
 
             if self.is_guessable_letter(answer[i]):
                 guessable += 1

--- a/src/_score/score_module.py
+++ b/src/_score/score_module.py
@@ -52,7 +52,7 @@ class Crossword(ScoreModule):
         # Default to full credit unless a hint modifier is present
         if log.item_id in self.modifiers:
             deduction = float(self.modifiers[log.item_id])
-            hint_factor = 1 - (- deduction / self.INITIAL_SCORE)
+            hint_factor = 1 - (-deduction / self.INITIAL_SCORE)
             score = (base_score * percent_correct) * hint_factor
             self.hint_deductions += (base_score * percent_correct) - score
         else:
@@ -70,8 +70,9 @@ class Crossword(ScoreModule):
     def calculate_score(self):
         super().calculate_score()
         if self.total_questions > 0:
-            self.hint_deductions = -1 * (self.hint_deductions /
-                                         self.total_questions)
+            self.hint_deductions = -1 * (
+                self.hint_deductions / self.total_questions
+            )
 
             # points lost represents the point value deduction
             # from incorrect letter guesses, sans hint deduction
@@ -94,16 +95,19 @@ class Crossword(ScoreModule):
         if len(submitted_chars) < max_len:
             submitted_chars += [" "] * (max_len - len(submitted_chars))
         for i in range(max_len):
-            if (i < len(answer_chars) and 
-                    self.is_guessable_letter(answer_chars[i])):
-                if i < len(submitted_chars) and submitted_chars[i] == ' ':
-                    submitted_chars[i] = '_'
+            if i < len(answer_chars) and self.is_guessable_letter(
+                answer_chars[i]
+            ):
+                if i < len(submitted_chars) and submitted_chars[i] == " ":
+                    submitted_chars[i] = "_"
         return "".join(submitted_chars)
 
     def get_feedback(self, log, answers):
         for play_log in self.logs:
-            if (play_log.log_type == Log.LogType.SCORE_WIDGET_INTERACTION
-                    and play_log.item_id == log.item_id):
+            if (
+                play_log.log_type == Log.LogType.SCORE_WIDGET_INTERACTION
+                and play_log.item_id == log.item_id
+            ):
                 return "Hint Received"
 
         return None
@@ -111,16 +115,11 @@ class Crossword(ScoreModule):
     def get_overview_items(self):
         overview = []
         if self.hint_deductions < 0:
-            overview.append({
-                "message": "Hint Deductions",
-                "value": self.hint_deductions
-            })
-        overview.append({
-            "message": "Points Lost",
-            "value": self.points_lost
-            })
-        overview.append({
-            "message": "Final Score",
-            "value": self.calculated_percent
-            })
+            overview.append(
+                {"message": "Hint Deductions", "value": self.hint_deductions}
+            )
+        overview.append({"message": "Points Lost", "value": self.points_lost})
+        overview.append(
+            {"message": "Final Score", "value": self.calculated_percent}
+        )
         return overview

--- a/src/_score/score_module.py
+++ b/src/_score/score_module.py
@@ -29,6 +29,10 @@ class Crossword(ScoreModule):
         guessable = 0
 
         for i in range(max_len):
+
+            if i >= len(answer):
+                break
+
             if self.is_guessable_letter(answer[i]):
                 guessable += 1
                 if answer[i] == response[i]:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,6 +1645,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/emscripten@^1.41.4":
+  version "1.41.5"
+  resolved "https://registry.yarnpkg.com/@types/emscripten/-/emscripten-1.41.5.tgz#5670e4b52b098691cb844b84ee48c9176699b68d"
+  integrity sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==
+
 "@types/eslint-scope@^3.7.7":
   version "3.7.7"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.7.tgz#3108bd5f18b0cdb277c867b3dd449c9ed7079ac5"
@@ -7029,15 +7034,15 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-materia-widget-dependencies@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/materia-widget-dependencies/-/materia-widget-dependencies-0.4.2.tgz#d6664f7c525ae624a0ca87579865b1864c53a2d7"
-  integrity sha512-JyyeE9HSRC9tyEPmsEC+UsfC51z+Y6xT8qzn+2PGvj6T/Mda/hFK/Uqw0WA5pE42+SpjYOaJ2B8CK0bT9rZ21A==
+materia-widget-dependencies@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/materia-widget-dependencies/-/materia-widget-dependencies-0.5.1.tgz#45dad52e1e2366bbafa7c3f5ee15d34be7690479"
+  integrity sha512-/CN3vfULbC3gB9XWqV0JtUzuivqbpAl/y83exnzg/+NlbSpYLrqFzzcCKdqG9LYIbBtZNggwBxLwteir9qmpHQ==
 
-materia-widget-development-kit@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-3.0.4.tgz#5fdea73976aa83463ca3c278d5fd8f2ac4830446"
-  integrity sha512-iwinME3Kh3WsIr/XMpIuxNadPkLzsWkFxsJAI5JiSr2VpWkgznUvKT/KNisWD1vdwF1QQQrRXaFbE0lMG5FNMQ==
+materia-widget-development-kit@3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/materia-widget-development-kit/-/materia-widget-development-kit-3.0.5.tgz#f8d5fa21e484551900228ca78512eab5300215e9"
+  integrity sha512-geH2iC8JQF+zTX1vY2WPzzja8IQT+0pNi1fdfKyI0tngrZEYxKiRQgKZXfbQW+DrLEvEpMsLu+FwTxuCMAHx3A==
   dependencies:
     "@babel/core" "^7.22.17"
     "@babel/preset-env" "^7.20.2"
@@ -7060,7 +7065,7 @@ materia-widget-development-kit@^3.0.4:
     hbs "^4.2.0"
     html-loader "^4.2.0"
     html-webpack-plugin "^5.5.3"
-    materia-widget-dependencies "0.4.2"
+    materia-widget-dependencies "0.5.1"
     mini-css-extract-plugin "^2.7.2"
     npm-check-updates "^16.10.9"
     path "^0.12.7"
@@ -7069,6 +7074,7 @@ materia-widget-development-kit@^3.0.4:
     postcss-preset-env "^9.1.3"
     postcss-scss "^4.0.8"
     prettier "^3.0.3"
+    pyodide "^0.29.0"
     raw-loader "^4.0.2"
     react "^18.2.0"
     react-dom "^18.2.0"
@@ -8938,6 +8944,14 @@ pupa@^3.1.0:
   integrity sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==
   dependencies:
     escape-goat "^4.0.0"
+
+pyodide@^0.29.0:
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.29.3.tgz#555ec43c09983a3cf3794c778e40084de24cfb95"
+  integrity sha512-22UBuhOJawj7vKUnS7/F3xK+515LJdjiMAHoCfuS6/PbHiOrSQVnYwDe+2sbVwiOZ3sMMexdXICew6NqOMQGgA==
+  dependencies:
+    "@types/emscripten" "^1.41.4"
+    ws "^8.5.0"
 
 qs@6.11.0:
   version "6.11.0"
@@ -11348,6 +11362,11 @@ ws@^8.18.0:
   version "8.18.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+
+ws@^8.5.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
+  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
 
 wsl-utils@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Resolves #82 by simply iterating over the length of `answer`, instead of calculating a max length that might result in out of bounds index references.

Additionally includes some miscellaneous cleanup: MWDK versioning, yarn lockfile, GH workflow corrections, and local configs for black to satisfy flake8 requirements.